### PR TITLE
fix: get_variation_months retornava valores absurdos em quedas grandes

### DIFF
--- a/script_get_fii_history.py
+++ b/script_get_fii_history.py
@@ -162,8 +162,9 @@ def get_variation_months(hist, to_month):
     last_date = datetime.strptime(hist[0]["date"], "%Y-%m-%d")
     if diff_month(datetime.today(), last_date) > 1 or first == 0:
         return 0
-    if first > last:
-        return ((first / last - 1) * 100) * -1
+    # Fórmula única: positivo pra alta, negativo pra baixa. O branch antigo
+    # `if first > last: ((first/last - 1) * 100) * -1` produzia números absurdos
+    # em quedas grandes (ex: -2300% em vez de -95% pra ações que despencaram).
     return (last / first - 1) * 100
 
 

--- a/script_get_stock_history.py
+++ b/script_get_stock_history.py
@@ -210,8 +210,9 @@ def get_variation_months(hist, to_month):
     last_date = datetime.strptime(hist[0]["date"], "%Y-%m-%d")
     if diff_month(datetime.today(), last_date) > 1 or first == 0:
         return 0
-    if first > last:
-        return ((first / last - 1) * 100) * -1
+    # Fórmula única: positivo pra alta, negativo pra baixa. O branch antigo
+    # `if first > last: ((first/last - 1) * 100) * -1` produzia números absurdos
+    # em quedas grandes (ex: SEQL3 24→1 dava -2300% em vez de -95.83%).
     return (last / first - 1) * 100
 
 


### PR DESCRIPTION
## Bug

Lista de "Desvalorizadas" mostrava valores absurdos pra ações que despencaram. Ex: **SEQL3 com -2300% de desvalorização** quando o real é -95.83% (caiu de ~R\$24 pra ~R\$1).

A tela de detalhe mostra o valor correto (95.8%) porque calcula no client com fórmula \`(last - first) / first * 100\`. A lista lê \`variationSixMonths\` pré-computado pelo script, que estava errado.

## Causa

\`get_variation_months\` tinha branch separado pra quedas com fórmula errada:

\`\`\`python
if first > last:
    return ((first / last - 1) * 100) * -1   # buggy
return (last / first - 1) * 100
\`\`\`

Pra SEQL3 (first=24, last=1): \`((24/1 - 1) * 100) * -1 = -2300%\`. Matemática quebrada — usa razão invertida.

## Fix

Fórmula única, padrão financeiro:

\`\`\`python
return (last / first - 1) * 100
\`\`\`

Naturalmente positivo pra alta, negativo pra baixa, limitado a -100% no pior caso. Aplicado em ambos scripts (stocks + FIIs).

## Pós-merge

Workflow \`get-stock-history-schedule\` precisa rodar em master pra reescrever \`stockHistory/*\` no Firebase com os valores corretos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)